### PR TITLE
Modify extconf.rb to look for R lib and headers in common directories as...

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -10,7 +10,7 @@ some_paths = ENV['PATH'].split(File::PATH_SEPARATOR) + %w[
   /Library/Frameworks/R.framework/Resources
 ]
 
-some_lib_paths = some_paths.map{|dir| "#{dir}/lib" }
+some_lib_paths = some_paths.map{|dir| File.join(dir, 'lib') }
 find_library('R', nil, *some_lib_paths)
 
 unless have_library("R")
@@ -18,7 +18,7 @@ unless have_library("R")
   exit 1
 end
 
-some_include_paths = some_paths.map{|dir| "#{dir}/include" } + %w[/usr/include/R]
+some_include_paths = some_paths.map{|dir| File.join(dir, 'include') } + %w[/usr/include/R]
 find_header('R.h', nil, *some_include_paths)
 
 unless have_header("R.h")


### PR DESCRIPTION
... well as config (similar to mysql2 gem).

This makes rsruby play nice with bundler with no additional configuration required in most cases.

(And THAT made all the developers on my team and our capistrano deploy scripts very happy....)
