### PR TITLE
Fix build on Ubuntu Quantal

### DIFF
--- a/ext/Converters.c
+++ b/ext/Converters.c
@@ -105,7 +105,7 @@ SEXP ruby_to_R(VALUE obj)
       str = rb_funcall(obj,rb_intern("inspect"),0);
       str = rb_funcall(str,rb_intern("slice"),2,INT2NUM(0),INT2NUM(60));
       sprintf(buf,"Unsupported object '%s' passed to R.\n",RSTRING_PTR(str));
-      rb_raise(rb_eArgError,buf);
+      rb_raise(rb_eArgError,"%s",buf);
       PROTECT(robj = NULL);       /* Protected to avoid stack inbalance */
     }
 

--- a/ext/R_eval.c
+++ b/ext/R_eval.c
@@ -61,7 +61,7 @@ SEXP do_eval_expr(SEXP e) {
     else {
       rb_eRException = rb_const_get(rb_cObject, 
 				    rb_intern("RException"));
-      rb_raise(rb_eRException, get_last_error_msg());
+      rb_raise(rb_eRException, "%s", get_last_error_msg());
       return NULL;
     }
   }


### PR DESCRIPTION
I couldn't get the current release branch of rsruby to build on the latest Ubuntu with the standard ruby package - it gives the following error:

```
$ sudo gem install rsruby -- --with-R-dir=$R_HOME --with-R-include=/usr/share/R/include
Building native extensions.  This could take a while...
ERROR:  Error installing rsruby:
ERROR: Failed to build gem native extension.

    /usr/bin/ruby1.9.1 extconf.rb --with-R-dir=/usr/lib/R --with-R-include=/usr/share/R/include
checking for main() in -lR... yes
checking for R.h... yes
creating Makefile

make
compiling robj.c
compiling rsruby.c
rsruby.c: In function ‘r_finalize’:
rsruby.c:104:3: warning: implicit declaration of function ‘Rf_KillAllDevices’ [-Wimplicit-function-    declaration]
rsruby.c: In function ‘rs_shutdown’:
rsruby.c:121:3: warning: implicit declaration of function ‘Rf_endEmbeddedR’ [-Wimplicit-function- declaration]
compiling Converters.c
Converters.c: In function ‘ruby_to_R’:
Converters.c:107:7: error: format not a string literal and no format arguments [-Werror=format-security]
Converters.c: In function ‘to_ruby_vector’:
Converters.c:356:25: warning: assignment discards ‘const’ qualifier from pointer target type [enabled by default]
Converters.c:384:21: warning: assignment discards ‘const’ qualifier from pointer target type [enabled by default]
Converters.c:310:9: warning: unused variable ‘params’ [-Wunused-variable]
Converters.c: In function ‘to_ruby_hash’:
Converters.c:601:10: warning: assignment discards ‘const’ qualifier from pointer target type    [enabled by default]
cc1: some warnings being treated as errors
make: *** [Converters.o] Error 1


Gem files will remain installed in /var/lib/gems/1.9.1/gems/rsruby-0.5.1.1 for inspection.
Results logged to /var/lib/gems/1.9.1/gems/rsruby-0.5.1.1/ext/gem_make.out
```

I thin kthe issue is similar to the compilation errors reported in this issue in eventmachine:
https://github.com/eventmachine/eventmachine/issues/346

...and the fix is very similar - I've modified a couple of the rb_raise calls to include the format string "%s" explicitly.

Thanks,
Ash.
