### PR TITLE
Removed reference to Rf_Printwarnings

### DIFF
--- a/ext/rsruby.h
+++ b/ext/rsruby.h
@@ -60,7 +60,7 @@
 # define CleanEd Rf_CleanEd
 extern void CleanEd(void);
 extern int R_CollectWarnings; 
-# define PrintWarnings Rf_PrintWarnings
+# define PrintWarnings() ; // NOTE: Rf_PrintWarnings removed in R 3.x
 extern void PrintWarnings(void);
 
 void Init_rsruby();


### PR DESCRIPTION
RsRuby will not link against R >= 3.0 as the Rf_PrintWarnings function has been removed.

This commit removes the reference to the function and does not provide an alternative. The change is required for RsRuby to be used with recent versions of R, but does prevent R warnings from being accessed from Ruby. I don't need that particular functionality, but if somebody does, let me know and I'll look into it.